### PR TITLE
FEATURE: add options for mobile

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -81,6 +81,7 @@ html.homepage-featured-topics {
           display: none;
         }
       }
+
       @media screen and (max-width: 450px) {
         width: 100%;
         margin: 0;
@@ -114,6 +115,19 @@ html.homepage-featured-topics {
           display: block;
           width: 100%;
           height: 100%;
+        }
+      }
+    }
+  }
+
+  &.-mobile-show-all {
+    @media screen and (max-width: 450px) {
+      .featured-topics {
+        flex-direction: column;
+        .featured-topic {
+          &:nth-of-type(n + 2) {
+            display: flex;
+          }
         }
       }
     }

--- a/common/common.scss
+++ b/common/common.scss
@@ -33,9 +33,7 @@ html.homepage-featured-topics {
     display: flex;
     justify-content: center;
     align-items: flex-start;
-    @media screen and (max-width: 600px) {
-      flex-wrap: wrap;
-    }
+
     .featured-topic {
       flex: 1 1 30%;
       max-width: 500px;
@@ -84,7 +82,6 @@ html.homepage-featured-topics {
 
       @media screen and (max-width: 450px) {
         width: 100%;
-        margin: 0;
         &:nth-of-type(n + 2) {
           display: none;
         }
@@ -93,16 +90,13 @@ html.homepage-featured-topics {
         margin: 0;
         padding: 1em 0 1.5em;
         font-size: $font-up-2;
-        a {
+        padding: 0.5em 1em 1em 1em a {
           display: -webkit-box;
           overflow: hidden;
           text-overflow: ellipsis;
           word-wrap: break-word;
           -webkit-line-clamp: 2;
           -webkit-box-orient: vertical;
-        }
-        @media screen and (max-width: 450px) {
-          padding: 1em 0 1em;
         }
       }
       .featured-topic-image {
@@ -120,14 +114,78 @@ html.homepage-featured-topics {
     }
   }
 
-  &.-mobile-show-all {
-    @media screen and (max-width: 450px) {
+  //same effect till max-width 600px
+  &.-mobile-stacked,
+  &.-mobile-horizontal {
+    .featured-topics {
+      justify-content: flex-start;
+      @media screen and (max-width: 999px) {
+        flex-direction: row;
+        gap: 1.25em;
+        padding-bottom: 1rem; //spacing for scroll on mobile
+        overflow-x: scroll;
+        .featured-topic {
+          flex-shrink: 0;
+          margin: 0;
+          &:nth-of-type(n + 5) {
+            display: flex;
+          }
+        }
+      }
+
+      @media screen and (max-width: 800px) {
+        .featured-topic {
+          flex-basis: 45%;
+          &:nth-of-type(n + 4) {
+            display: flex;
+          }
+        }
+      }
+    }
+  }
+
+  @media screen and (max-width: 600px) {
+    &.-mobile-stacked {
       .featured-topics {
         flex-direction: column;
+        align-items: center;
+        gap: 0;
         .featured-topic {
+          flex-basis: 100%;
+          margin: 0;
+          &:nth-of-type(n + 3) {
+            display: flex;
+          }
           &:nth-of-type(n + 2) {
             display: flex;
           }
+
+          h3 {
+            padding-top: 0.25em;
+          }
+        }
+      }
+    }
+    &.-mobile-horizontal {
+      .featured-topics {
+        .featured-topic {
+          flex-basis: 75%;
+
+          &:nth-of-type(n + 3) {
+            display: flex;
+          }
+          &:nth-of-type(n + 2) {
+            display: flex;
+          }
+        }
+      }
+    }
+  }
+  @media screen and (max-width: 400px) {
+    &.-mobile-horizontal {
+      .featured-topics {
+        .featured-topic {
+          flex-basis: 85%;
         }
       }
     }

--- a/javascripts/discourse/components/featured-homepage-topics.js
+++ b/javascripts/discourse/components/featured-homepage-topics.js
@@ -114,4 +114,17 @@ export default Component.extend({
       return false;
     }
   },
+
+  get mobileStyle() {
+    if (
+      settings.show_all_always &&
+      settings.mobile_style === "stacked_on_smaller_screens"
+    ) {
+      return "-mobile-stacked";
+    } else if (settings.show_all_always) {
+      return "-mobile-horizontal";
+    } else {
+      return;
+    }
+  },
 });

--- a/javascripts/discourse/templates/components/featured-homepage-topics.hbs
+++ b/javascripts/discourse/templates/components/featured-homepage-topics.hbs
@@ -3,7 +3,12 @@
     {{#if featuredTagTopics}}
       <div class="custom-homepage-wrapper">
         <div class="custom-homepage">
-          <div class="featured-topic-wrapper">
+          <div
+            class={{concat-class
+              "featured-topic-wrapper"
+              (if (theme-setting "show_all_on_mobile") "-mobile-show-all")
+            }}
+          >
             {{showTitle}}
             <div class="featured-topics">
               {{#each featuredTagTopics as |t|}}

--- a/javascripts/discourse/templates/components/featured-homepage-topics.hbs
+++ b/javascripts/discourse/templates/components/featured-homepage-topics.hbs
@@ -3,12 +3,7 @@
     {{#if featuredTagTopics}}
       <div class="custom-homepage-wrapper">
         <div class="custom-homepage">
-          <div
-            class={{concat-class
-              "featured-topic-wrapper"
-              (if (theme-setting "show_all_on_mobile") "-mobile-show-all")
-            }}
-          >
+          <div class={{concat-class "featured-topic-wrapper" mobileStyle}}>
             {{showTitle}}
             <div class="featured-topics">
               {{#each featuredTagTopics as |t|}}

--- a/settings.yml
+++ b/settings.yml
@@ -39,6 +39,18 @@ sort_by_created:
   default: true
   description: Disable to sort by latest activity
 
+show_all_on_mobile:
+  default: false
+  description: By default only 1 is shown on mobile. Checking this setting will show all.
+
+mobile_style:
+  default: stacked
+  type: enum
+  choices:
+    - stacked
+    - horizontal_scroll
+  description: If more than one is choses to be shown on mobile, these will be shown stacked by default. You can change this behaviour to have them shown horizontally.
+
 featured_content_position:
   default: discovery_list_controls_above
   type: enum

--- a/settings.yml
+++ b/settings.yml
@@ -39,17 +39,17 @@ sort_by_created:
   default: true
   description: Disable to sort by latest activity
 
-show_all_on_mobile:
+show_all_always:
   default: false
-  description: By default only 1 is shown on mobile. Checking this setting will show all.
+  description: By default the amount of shown topics is decreased with the screen size, down to only 1 on mobile. Checking this setting will show all on any screen size.
 
 mobile_style:
-  default: stacked
+  default: horizontal_scroll
   type: enum
   choices:
-    - stacked
     - horizontal_scroll
-  description: If more than one is choses to be shown on mobile, these will be shown stacked by default. You can change this behaviour to have them shown horizontally.
+    - stacked_on_smaller_screens
+  description: If <code>show_all_always</code> is checked, the topics will be shown via a horizontal scroll by default. You can change this behaviour on smaller screens, and choose to stack them on anything smaller than 600px.
 
 featured_content_position:
   default: discovery_list_controls_above


### PR DESCRIPTION
### Before 
Incrementally hide topic from the line-up, down to 1 on mobile

### Changes
Added 2 settings
<img width="630" alt="image" src="https://user-images.githubusercontent.com/101828855/200842208-f685da74-3147-4f2a-ad43-2663b52edd37.png">
* one to override the default and always show all featured topics on smaller screens
* one to choose the behaviour of how to show it

#### Option 1: slider
This is the new mobile default behaviour
<img width="582" alt="image" src="https://user-images.githubusercontent.com/101828855/200842536-c0e003f9-18db-4f6b-9d68-9fef06ebcd06.png">

#### Option 2: stacked
On the smallest screens you can opt to stack them
<img width="451" alt="image" src="https://user-images.githubusercontent.com/101828855/200842652-afc34da4-5dd4-4c2a-b0d9-2fb76ebac761.png">

