### PR TITLE
REFACTOR: use Glimmer, add archive feature

### DIFF
--- a/javascripts/discourse/components/featured-homepage-topics.hbs
+++ b/javascripts/discourse/components/featured-homepage-topics.hbs
@@ -1,12 +1,23 @@
-{{#if showFor}}
-  {{#if showHere}}
-    {{#if featuredTagTopics}}
-      <div class="custom-homepage-wrapper">
+{{#if this.showFor}}
+  {{#if this.showHere}}
+    <div
+      class="custom-homepage-wrapper"
+      {{did-insert this.getBannerTopics}}
+      {{did-insert this.checkShowHere}}
+    >
+      {{#if this.featuredTagTopics}}
+
         <div class="custom-homepage">
-          <div class={{concat-class "featured-topic-wrapper" mobileStyle}}>
-            {{showTitle}}
+          <div class={{concat "featured-topic-wrapper" this.mobileStyle}}>
+
+            {{#if (theme-setting "show_title")}}
+              <h2>
+                {{this.featuredTitle}}
+              </h2>
+            {{/if}}
+
             <div class="featured-topics">
-              {{#each featuredTagTopics as |t|}}
+              {{#each this.featuredTagTopics as |t|}}
                 <div class="featured-topic">
                   <div
                     class="featured-topic-image"
@@ -27,7 +38,8 @@
             </div>
           </div>
         </div>
-      </div>
-    {{/if}}
+      {{/if}}
+    </div>
+
   {{/if}}
 {{/if}}

--- a/settings.yml
+++ b/settings.yml
@@ -43,6 +43,10 @@ show_all_always:
   default: false
   description: By default the amount of shown topics is decreased with the screen size, down to only 1 on mobile. Checking this setting will show all on any screen size.
 
+hide_archived_topics:
+  default: true
+  description: Hide archived topics from the featured topic list
+
 mobile_style:
   default: horizontal_scroll
   type: enum


### PR DESCRIPTION
This refactors the component to use Glimmer and adds a feature to hide archived topics. Hiding archived topics means that a topic timer can be used to remove topics from the banner. 