### PR TITLE
DEV: swap out archived feature for closed

### DIFF
--- a/javascripts/discourse/components/featured-homepage-topics.js
+++ b/javascripts/discourse/components/featured-homepage-topics.js
@@ -98,7 +98,7 @@ export default class FeaturedHomepageTopics extends Component {
     this.featuredTagTopics = topicList.topics
       .filter(
         (topic) =>
-          topic.image_url && (!settings.hide_archived_topics || !topic.archived)
+          topic.image_url && (!settings.hide_closed_topics || !topic.closed)
       )
       .slice(0, settings.number_of_topics);
   }

--- a/settings.yml
+++ b/settings.yml
@@ -43,9 +43,9 @@ show_all_always:
   default: false
   description: By default the amount of shown topics is decreased with the screen size, down to only 1 on mobile. Checking this setting will show all on any screen size.
 
-hide_archived_topics:
-  default: true
-  description: Hide archived topics from the featured topic list
+hide_closed_topics:
+  default: false
+  description: Hide closed topics from the featured topic list
 
 mobile_style:
   default: horizontal_scroll


### PR DESCRIPTION
Originally added this archive functionality for a customer that wanted to automatically remove topics from this component, but mistakenly thought we had a topic timer for archiving topics. 

This accomplishes the same thing, but uses closed topics instead (which we definitely have a topic timer for!) 

Swapping the default to false because closed topics are more common and I don't want to surprise anyone already using the component. 