### PR TITLE
FEATURE: Add collapsible feature

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -205,7 +205,6 @@ button.featured-topic-toggle {
     margin: 0;
   }
   gap: 0.35em;
-  width: 100%;
   justify-content: flex-start;
   margin-bottom: 1.5em;
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -200,15 +200,12 @@ body:not(.staff) {
 }
 
 button.featured-topic-toggle {
-  display: flex;
-  align-items: center;
-  gap: 0.5em;
+  .d-button-label + .d-icon {
+    order: -1;
+    margin: 0;
+  }
+  gap: 0.35em;
   width: 100%;
-  padding: 0.75em 0;
-  margin-bottom: 1.5em;
-  border: none;
-  border-bottom: 1px solid var(--primary-low);
-  background: none;
-  font-weight: 600;
   justify-content: flex-start;
+  margin-bottom: 1.5em;
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -198,3 +198,17 @@ body:not(.staff) {
     display: none;
   }
 }
+
+button.featured-topic-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  width: 100%;
+  padding: 0.75em 0;
+  margin-bottom: 1.5em;
+  border: none;
+  border-bottom: 1px solid var(--primary-low);
+  background: none;
+  font-weight: 600;
+  justify-content: flex-start;
+}

--- a/javascripts/discourse/components/featured-homepage-topics.hbs
+++ b/javascripts/discourse/components/featured-homepage-topics.hbs
@@ -8,6 +8,7 @@
       <div class="custom-homepage">
         {{#if (theme-setting "make_collapsible")}}
           <button
+            type="button"
             class={{concat
               "featured-topic-toggle"
               " "
@@ -33,12 +34,15 @@
             (if (and toggleTopics (theme-setting "make_collapsible")) "hidden")
           }}
         >
-          {{#if (theme-setting "show_title")}}
-            {{#unless (theme-setting "make_collapsible")}}
-              <h2>
-                {{this.featuredTitle}}
-              </h2>
-            {{/unless}}
+          {{#if
+            (and
+              (theme-setting "show_title")
+              (not (theme-setting "make_collapsible"))
+            )
+          }}
+            <h2>
+              {{this.featuredTitle}}
+            </h2>
           {{/if}}
 
           <div class="featured-topics">

--- a/javascripts/discourse/components/featured-homepage-topics.hbs
+++ b/javascripts/discourse/components/featured-homepage-topics.hbs
@@ -33,11 +33,12 @@
             (if (and toggleTopics (theme-setting "make_collapsible")) "hidden")
           }}
         >
-
           {{#if (theme-setting "show_title")}}
-            <h2>
-              {{this.featuredTitle}}
-            </h2>
+            {{#unless (theme-setting "make_collapsible")}}
+              <h2>
+                {{this.featuredTitle}}
+              </h2>
+            {{/unless}}
           {{/if}}
 
           <div class="featured-topics">

--- a/javascripts/discourse/components/featured-homepage-topics.hbs
+++ b/javascripts/discourse/components/featured-homepage-topics.hbs
@@ -13,7 +13,7 @@
               (if toggleTopics "is-open")
             }}
             @action={{action "toggle"}}
-            @translatedLabel="{{this.featuredTitle}}"
+            @translatedLabel={{this.featuredTitle}}
           >
             {{#if toggleTopics}}
               {{d-icon "angle-right"}}

--- a/javascripts/discourse/components/featured-homepage-topics.hbs
+++ b/javascripts/discourse/components/featured-homepage-topics.hbs
@@ -7,24 +7,20 @@
     {{#if this.featuredTagTopics}}
       <div class="custom-homepage">
         {{#if (theme-setting "make_collapsible")}}
-          <button
-            type="button"
-            class={{concat
+          <DButton
+            @class={{concat-class
               "featured-topic-toggle"
-              " "
               (if toggleTopics "is-open")
             }}
-            {{action "toggle"}}
+            @action={{action "toggle"}}
+            @translatedLabel="{{this.featuredTitle}}"
           >
             {{#if toggleTopics}}
               {{d-icon "angle-right"}}
             {{else}}
               {{d-icon "angle-down"}}
             {{/if}}
-            <span>
-              {{this.featuredTitle}}
-            </span>
-          </button>
+          </DButton>
         {{/if}}
 
         <div

--- a/javascripts/discourse/components/featured-homepage-topics.hbs
+++ b/javascripts/discourse/components/featured-homepage-topics.hbs
@@ -5,9 +5,34 @@
     {{did-insert this.checkShowHere}}
   >
     {{#if this.featuredTagTopics}}
-
       <div class="custom-homepage">
-        <div class={{concat-class "featured-topic-wrapper" this.mobileStyle}}>
+        {{#if (theme-setting "make_collapsible")}}
+          <button
+            class={{concat
+              "featured-topic-toggle"
+              " "
+              (if toggleTopics "is-open")
+            }}
+            {{action "toggle"}}
+          >
+            {{#if toggleTopics}}
+              {{d-icon "angle-right"}}
+            {{else}}
+              {{d-icon "angle-down"}}
+            {{/if}}
+            <span>
+              {{this.featuredTitle}}
+            </span>
+          </button>
+        {{/if}}
+
+        <div
+          class={{concat-class
+            "featured-topic-wrapper"
+            this.mobileStyle
+            (if (and toggleTopics (theme-setting "make_collapsible")) "hidden")
+          }}
+        >
 
           {{#if (theme-setting "show_title")}}
             <h2>

--- a/javascripts/discourse/components/featured-homepage-topics.js
+++ b/javascripts/discourse/components/featured-homepage-topics.js
@@ -12,18 +12,21 @@ export default class FeaturedHomepageTopics extends Component {
   @service store;
   @service siteSettings;
   @service currentUser;
+  @service keyValueStore;
+
   @tracked featuredTagTopics = null;
   @tracked toggleTopics =
-    localStorage.getItem(this.toggleTopicsState) === "true" || false;
+    this.keyValueStore.getItem("toggleTopicsState") === "true" || false;
 
   constructor() {
     super(...arguments);
     this.router.on("routeDidChange", this.checkShowHere);
   }
 
+  @action
   toggle() {
     this.toggleTopics = !this.toggleTopics;
-    localStorage.setItem(this.toggleTopicsState, this.toggleTopics);
+    this.keyValueStore.setItem("toggleTopicsState", this.toggleTopics);
   }
 
   willDestroy() {

--- a/javascripts/discourse/components/featured-homepage-topics.js
+++ b/javascripts/discourse/components/featured-homepage-topics.js
@@ -13,6 +13,13 @@ export default class FeaturedHomepageTopics extends Component {
   @service siteSettings;
   @service currentUser;
   @tracked featuredTagTopics = null;
+  @tracked toggleTopics =
+    localStorage.getItem(this.toggleTopicsState) === "true" || false;
+
+  toggle() {
+    this.toggleTopics = !this.toggleTopics;
+    localStorage.setItem(this.toggleTopicsState, this.toggleTopics);
+  }
 
   constructor() {
     super(...arguments);

--- a/javascripts/discourse/components/featured-homepage-topics.js
+++ b/javascripts/discourse/components/featured-homepage-topics.js
@@ -16,14 +16,14 @@ export default class FeaturedHomepageTopics extends Component {
   @tracked toggleTopics =
     localStorage.getItem(this.toggleTopicsState) === "true" || false;
 
-  toggle() {
-    this.toggleTopics = !this.toggleTopics;
-    localStorage.setItem(this.toggleTopicsState, this.toggleTopics);
-  }
-
   constructor() {
     super(...arguments);
     this.router.on("routeDidChange", this.checkShowHere);
+  }
+
+  toggle() {
+    this.toggleTopics = !this.toggleTopics;
+    localStorage.setItem(this.toggleTopicsState, this.toggleTopics);
   }
 
   willDestroy() {

--- a/settings.yml
+++ b/settings.yml
@@ -7,10 +7,6 @@ number_of_topics:
   max: 5
   description: Display up to 5 topics at max-width
 
-make_collapsible:
-  default: false
-  description: Make the entire component collapsible
-
 hide_featured_tag:
   default: false
   description: When enabled the tag "featured tag" set above will be invisible to normal users when viewing topics.
@@ -31,6 +27,10 @@ show_for:
     - everyone
     - logged_in
     - logged_out
+
+make_collapsible:
+  default: false
+  description: Make the entire component collapsible
 
 show_title:
   default: false

--- a/settings.yml
+++ b/settings.yml
@@ -34,7 +34,7 @@ show_for:
 
 show_title:
   default: false
-  description: displays the text set below
+  description: displays the text set below (title is always shown when make_collapsible is on)
 
 title_text:
   default: "Featured Topics"

--- a/settings.yml
+++ b/settings.yml
@@ -7,6 +7,10 @@ number_of_topics:
   max: 5
   description: Display up to 5 topics at max-width
 
+make_collapsible:
+  default: false
+  description: Make the entire component collapsible
+
 hide_featured_tag:
   default: false
   description: When enabled the tag "featured tag" set above will be invisible to normal users when viewing topics.


### PR DESCRIPTION
Adds an optional collapsible heading to the component.

<img width="688" alt="image" src="https://github.com/discourse/discourse-homepage-feature-component/assets/37538241/9554be2e-2e9b-445b-b9a0-cb9d9434634d">


<img width="1046" alt="image" src="https://github.com/discourse/discourse-homepage-feature-component/assets/37538241/4db30738-8cea-4e2b-b86b-8e9a579ac2c3">