### PR TITLE
DEV: refactor for responsive image sizes, migrate to tags setting, new specs

### DIFF
--- a/about.json
+++ b/about.json
@@ -2,5 +2,11 @@
   "name": "Homepage Feature",
   "component": true,
   "about_url": "https://meta.discourse.org/t/homepage-feature-component/144264",
-  "license_url": "https://github.com/discourse/discourse-homepage-feature-component/blob/main/LICENSE"
+  "license_url": "https://github.com/discourse/discourse-homepage-feature-component/blob/main/LICENSE",
+  "modifiers": {
+    "topic_thumbnail_sizes": {
+      "type": "setting",
+      "value": "featured_image_sizes"
+    }
+  }
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -138,16 +138,17 @@ html.homepage-featured-topics {
         }
 
         .featured-topic-image {
+          display: block;
           height: 200px;
           max-width: 450px;
           width: 100%;
-          background-size: cover;
-          background-position: center center;
 
-          a {
+          img {
             display: block;
             width: 100%;
             height: 100%;
+            object-fit: cover;
+            object-position: center center;
           }
         }
       }
@@ -267,13 +268,6 @@ html.homepage-featured-topics {
           var(--primary-low);
       }
     }
-  }
-}
-
-body:not(.staff) {
-  .tag-drop li[data-name="#{$featured-tag}"],
-  [data-tag-name="#{$featured-tag}"] {
-    display: none;
   }
 }
 

--- a/javascripts/discourse/api-initializers/hide-featured-tags.js
+++ b/javascripts/discourse/api-initializers/hide-featured-tags.js
@@ -1,0 +1,32 @@
+import { settings } from "virtual:theme";
+import { apiInitializer } from "discourse/lib/api";
+
+export default apiInitializer((api) => {
+  if (!settings.hide_featured_tag) {
+    return;
+  }
+
+  if (api.getCurrentUser()?.staff) {
+    return;
+  }
+
+  const tags = settings.featured_tag
+    .split("|")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+
+  if (tags.length === 0) {
+    return;
+  }
+
+  const selectors = tags
+    .flatMap((tag) => [
+      `.tag-drop li[data-name="${tag}"]`,
+      `[data-tag-name="${tag}"]`,
+    ])
+    .join(", ");
+
+  const style = document.createElement("style");
+  style.textContent = `${selectors} { display: none !important; }`;
+  document.head.appendChild(style);
+});

--- a/javascripts/discourse/components/featured-homepage-topics.gjs
+++ b/javascripts/discourse/components/featured-homepage-topics.gjs
@@ -1,14 +1,16 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { concat, fn } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { cancel } from "@ember/runloop";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import DButton from "discourse/components/d-button";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import discourseDebounce from "discourse/lib/debounce";
 import getURL from "discourse/lib/get-url";
 import { emojiUnescape } from "discourse/lib/text";
 import { defaultHomepage } from "discourse/lib/utilities";
@@ -32,17 +34,19 @@ export default class FeaturedHomepageTopics extends Component {
   @tracked currentPageIndex = 0;
   @tracked featuredTopicsAvailable = 0;
   @tracked actualTopicsDisplayed = 0;
+  filteredTopics = [];
 
   constructor() {
     super(...arguments);
     this.router.on("routeDidChange", this.checkShowHere);
-    window.addEventListener("resize", this.getBannerTopics);
+    window.addEventListener("resize", this.onResize);
   }
 
   willDestroy() {
     super.willDestroy(...arguments);
     this.router.off("routeDidChange", this.checkShowHere);
-    window.removeEventListener("resize", this.getBannerTopics);
+    window.removeEventListener("resize", this.onResize);
+    cancel(this._resizeHandler);
   }
 
   @action
@@ -113,19 +117,73 @@ export default class FeaturedHomepageTopics extends Component {
   }
 
   topicHref(t) {
-    return getURL(
-      `/t/${t.slug}/${t.id}/${
-        settings.always_link_to_first_post ? "" : t.last_read_post_number
-      }`
-    );
+    const postNumber = settings.always_link_to_first_post
+      ? null
+      : t.last_read_post_number;
+
+    const suffix = postNumber ? `/${postNumber}` : "";
+    return getURL(`/t/${t.slug}/${t.id}${suffix}`);
+  }
+
+  featuredImageSrcset(t) {
+    if (!t.thumbnails) {
+      return null;
+    }
+
+    const seenWidths = new Set();
+    const candidates = [];
+
+    for (const thumb of t.thumbnails) {
+      // skip the original (max_width is null) and any duplicate widths that
+      // occur when a registered size is larger than the source image
+      if (!thumb.max_width || !thumb.width || seenWidths.has(thumb.width)) {
+        continue;
+      }
+
+      seenWidths.add(thumb.width);
+      candidates.push(`${thumb.url} ${thumb.width}w`);
+    }
+
+    return candidates.length ? candidates.join(", ") : null;
+  }
+
+  get featuredTags() {
+    return settings.featured_tag
+      .split("|")
+      .map((tag) => tag.trim())
+      .filter(Boolean);
   }
 
   @action
   async getBannerTopics() {
-    if (!settings.featured_tag) {
+    if (this.featuredTags.length === 0) {
       return;
     }
 
+    const sortOrder = settings.sort_by_created ? "created" : "activity";
+    const topicList = await this.store.findFiltered("topicList", {
+      filter: "latest",
+      params: {
+        tags: this.featuredTags,
+        order: sortOrder,
+      },
+    });
+
+    this.filteredTopics = topicList.topics
+      .filter(
+        (topic) =>
+          topic.image_url && (!settings.hide_closed_topics || !topic.closed)
+      )
+      .slice(
+        0,
+        Math.max(settings.number_of_topics, settings.max_number_of_topics)
+      );
+
+    this.featuredTopicsAvailable = this.filteredTopics.length;
+    this.updateDisplayedTopics();
+  }
+
+  updateDisplayedTopics() {
     this.actualTopicsDisplayed = settings.number_of_topics;
     if (!settings.show_all_always) {
       // Sizes here are based on the existing resize boundaries in the CSS
@@ -140,35 +198,23 @@ export default class FeaturedHomepageTopics extends Component {
       }
     }
 
-    const sortOrder = settings.sort_by_created ? "created" : "activity";
-    const topicList = await this.store.findFiltered("topicList", {
-      filter: "latest",
-      params: {
-        tags: [`${settings.featured_tag}`],
-        order: sortOrder,
-      },
-    });
-
-    const filteredTopics = topicList.topics
-      .filter(
-        (topic) =>
-          topic.image_url && (!settings.hide_closed_topics || !topic.closed)
-      )
-      .slice(
-        0,
-        Math.max(settings.number_of_topics, settings.max_number_of_topics)
-      );
-
-    this.featuredTopicsAvailable = filteredTopics.length;
-
     const firstFeaturedTopicIndex =
       this.currentPageIndex * this.actualTopicsDisplayed;
     const lastFeaturedTopicIndex =
       firstFeaturedTopicIndex + this.actualTopicsDisplayed;
 
-    this.featuredTagTopics = filteredTopics.slice(
+    this.featuredTagTopics = this.filteredTopics.slice(
       firstFeaturedTopicIndex,
       lastFeaturedTopicIndex
+    );
+  }
+
+  @action
+  onResize() {
+    this._resizeHandler = discourseDebounce(
+      this,
+      this.updateDisplayedTopics,
+      100
     );
   }
 
@@ -207,7 +253,7 @@ export default class FeaturedHomepageTopics extends Component {
       this.currentPageIndex -= 1;
     }
 
-    this.getBannerTopics();
+    this.updateDisplayedTopics();
   }
 
   @action
@@ -220,7 +266,7 @@ export default class FeaturedHomepageTopics extends Component {
       this.currentPageIndex += 1;
     }
 
-    this.getBannerTopics();
+    this.updateDisplayedTopics();
   }
 
   get pageProgressArray() {
@@ -244,7 +290,7 @@ export default class FeaturedHomepageTopics extends Component {
   setPageIndex(pageIndex, event) {
     this.currentPageIndex = pageIndex;
     event?.preventDefault();
-    this.getBannerTopics();
+    this.updateDisplayedTopics();
   }
 
   pageNumberTitle(pageIndex) {
@@ -305,22 +351,21 @@ export default class FeaturedHomepageTopics extends Component {
                 <div class="featured-topics">
                   {{#each this.featuredTagTopics as |t|}}
                     <div class="featured-topic">
-                      <div
+                      <a
                         class="featured-topic-image"
-                        style={{htmlSafe
-                          (concat "background-image: url(" t.image_url ")")
-                        }}
+                        href={{this.topicHref t}}
+                        aria-hidden="true"
+                        tabindex="-1"
                       >
-                        {{! template-lint-disable no-invalid-link-text }}
-                        <a href={{this.topicHref t}}></a>
-                      </div>
+                        <img
+                          src={{t.image_url}}
+                          srcset={{this.featuredImageSrcset t}}
+                          sizes="(max-width: 460px) 100vw, 450px"
+                          alt=""
+                        />
+                      </a>
                       <h3>
-                        <a
-                          href={{this.topicHref t}}
-                          role="heading"
-                          aria-level="2"
-                          data-topic-id={{t.id}}
-                        >
+                        <a href={{this.topicHref t}} data-topic-id={{t.id}}>
                           {{htmlSafe (this.emojiTitle t.fancy_title)}}
                         </a>
                       </h3>

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,7 +6,7 @@ en:
       number_of_topics: Display up to 5 topics at max-width
       max_number_of_topics: Maximum number of featured topics. If set higher than number_of_topics then arrows will be displayed for paging through the topics.
       pages_loop: If pagination is enabled (max_number_of_topics > number_of_topics), pages continue back to the first page after the last.
-      hide_featured_tag: When enabled the tag "featured tag" set above will be invisible to normal users when viewing topics.
+      hide_featured_tag: When enabled the featured tag(s) set above will be invisible to normal users when viewing topics. Staff can still see them.
       show_on: top_menu refers to pages set in the <a href="%{base_path}/admin/site_settings/category/all_results?filter=top_menu">top menu site setting</a>
       make_collapsible: Make the entire component collapsible
       show_title: displays the text set below (title is always shown when make_collapsible is on)
@@ -16,3 +16,4 @@ en:
       always_link_to_first_post: Always link to the first post in the topic, even if it has been read before
       mobile_style: If <code>show_all_always</code> is checked, the topics will be shown via a horizontal scroll by default. You can change this behaviour on smaller screens, and choose to stack them on anything smaller than 600px.
       featured_content_position: Advanced theme development&colon; this changes the plugin outlet for the component
+      featured_image_sizes: The resized image variants made available to the featured images, as <code>WIDTHxHEIGHT</code> values. The browser picks the smallest one that fits the slot at the current screen size and pixel density, which saves bandwidth and speeds up page load. Provide a few sizes covering standard and high-resolution screens. Discourse generates these in the background, so they may take a moment to appear the first time after changing this; until then the full-size image is used.

--- a/migrations/settings/0001-featured-tag-to-tag-list.js
+++ b/migrations/settings/0001-featured-tag-to-tag-list.js
@@ -1,0 +1,9 @@
+// `featured_tag` changed from a single string setting to a tag list
+// (type: list, list_type: tag). A previously saved value such as "featured" is
+// already a valid single-item list value, so no transformation is needed — but
+// this migration must exist so the existing value survives the change in setting
+// type. Without it, the old override is dropped and the setting resets to its
+// default.
+export default function migrate(settings) {
+  return settings;
+}

--- a/settings.yml
+++ b/settings.yml
@@ -1,4 +1,6 @@
 featured_tag:
+  type: list
+  list_type: tag
   default: featured
 
 number_of_topics:
@@ -15,7 +17,7 @@ pages_loop:
   default: false
 
 hide_featured_tag:
-  default: false
+  default: true
 
 show_on:
   default: homepage
@@ -68,3 +70,7 @@ featured_content_position:
     - above_main_container
     - below_discovery_categories
     - discovery_list_controls_above
+
+featured_image_sizes:
+  default: "300x300|600x600|900x900"
+  type: list

--- a/spec/system/featured_images_spec.rb
+++ b/spec/system/featured_images_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe "Featured images" do
+  let!(:theme) { upload_theme_component }
+
+  fab!(:tag) { Fabricate(:tag, name: "featured") }
+  fab!(:upload, :image_upload)
+  fab!(:topic) { Fabricate(:topic_with_op, image_upload: upload, tags: [tag]) }
+
+  it "renders the featured image as an <img> element with a source" do
+    visit("/")
+
+    expect(page).to have_css(".featured-topic .featured-topic-image img[src]")
+  end
+
+  it "links the image to the topic but keeps it out of the tab order" do
+    visit("/")
+
+    image_link = find(".featured-topic .featured-topic-image")
+    expect(image_link["href"]).to include("/t/#{topic.slug}/#{topic.id}")
+    expect(image_link["tabindex"]).to eq("-1")
+    expect(image_link["aria-hidden"]).to eq("true")
+  end
+end

--- a/spec/system/featured_tags_spec.rb
+++ b/spec/system/featured_tags_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe "Featured tags" do
+  let!(:theme) { upload_theme_component }
+
+  fab!(:featured_tag) { Fabricate(:tag, name: "featured") }
+  fab!(:spotlight_tag) { Fabricate(:tag, name: "spotlight") }
+  fab!(:upload, :image_upload)
+
+  fab!(:featured_topic) { Fabricate(:topic_with_op, image_upload: upload, tags: [featured_tag]) }
+  fab!(:spotlight_topic) { Fabricate(:topic_with_op, image_upload: upload, tags: [spotlight_tag]) }
+
+  describe "selecting topics by tag" do
+    it "features topics from a single tag" do
+      visit("/")
+
+      expect(page).to have_css(".featured-topics .featured-topic", count: 1)
+    end
+
+    it "features topics from any of the configured tags" do
+      theme.update_setting(:featured_tag, "featured|spotlight")
+      theme.save!
+
+      visit("/")
+
+      expect(page).to have_css(".featured-topics .featured-topic", count: 2)
+    end
+  end
+
+  describe "hiding the featured tag from regular users" do
+    # checked on the topic page, where the topic's own tags always render; the
+    # initializer that hides them runs globally, not just where the component shows
+    it "is hidden from anonymous users by default" do
+      visit("/t/#{featured_topic.slug}/#{featured_topic.id}")
+
+      # the tag is still in the DOM, but hidden via the injected style
+      expect(page).to have_css("[data-tag-name='featured']", visible: :all)
+      expect(page).to have_no_css("[data-tag-name='featured']")
+    end
+
+    it "is visible to staff" do
+      sign_in(Fabricate(:admin))
+
+      visit("/t/#{featured_topic.slug}/#{featured_topic.id}")
+
+      expect(page).to have_css("[data-tag-name='featured']")
+    end
+
+    it "is visible to everyone when the setting is disabled" do
+      theme.update_setting(:hide_featured_tag, false)
+      theme.save!
+
+      visit("/t/#{featured_topic.slug}/#{featured_topic.id}")
+
+      expect(page).to have_css("[data-tag-name='featured']")
+    end
+  end
+end


### PR DESCRIPTION
Cleaning this component up: 

* Images now use srcset so they're not larger than they need to be, available sizes can be adjusted using a new setting `featured_image_sizes`

* Migrating to the tags setting type, and this can now support multiple tags 

* Fixing the `hide_featured_tag` setting... this wasn't working and the tags were always hidden, now it's optional 

* A couple accessibility fixes to avoid empty image links

* The window `resize` handler no longer refetches topics from the server on every event

* New specs to cover these updates 