### PR TITLE
REVERT: remove `featured_image_sizes` and thumbnail modifier

### DIFF
--- a/about.json
+++ b/about.json
@@ -2,11 +2,5 @@
   "name": "Homepage Feature",
   "component": true,
   "about_url": "https://meta.discourse.org/t/homepage-feature-component/144264",
-  "license_url": "https://github.com/discourse/discourse-homepage-feature-component/blob/main/LICENSE",
-  "modifiers": {
-    "topic_thumbnail_sizes": {
-      "type": "setting",
-      "value": "featured_image_sizes"
-    }
-  }
+  "license_url": "https://github.com/discourse/discourse-homepage-feature-component/blob/main/LICENSE"
 }

--- a/javascripts/discourse/components/featured-homepage-topics.gjs
+++ b/javascripts/discourse/components/featured-homepage-topics.gjs
@@ -125,28 +125,6 @@ export default class FeaturedHomepageTopics extends Component {
     return getURL(`/t/${t.slug}/${t.id}${suffix}`);
   }
 
-  featuredImageSrcset(t) {
-    if (!t.thumbnails) {
-      return null;
-    }
-
-    const seenWidths = new Set();
-    const candidates = [];
-
-    for (const thumb of t.thumbnails) {
-      // skip the original (max_width is null) and any duplicate widths that
-      // occur when a registered size is larger than the source image
-      if (!thumb.max_width || !thumb.width || seenWidths.has(thumb.width)) {
-        continue;
-      }
-
-      seenWidths.add(thumb.width);
-      candidates.push(`${thumb.url} ${thumb.width}w`);
-    }
-
-    return candidates.length ? candidates.join(", ") : null;
-  }
-
   get featuredTags() {
     return settings.featured_tag
       .split("|")
@@ -357,12 +335,7 @@ export default class FeaturedHomepageTopics extends Component {
                         aria-hidden="true"
                         tabindex="-1"
                       >
-                        <img
-                          src={{t.image_url}}
-                          srcset={{this.featuredImageSrcset t}}
-                          sizes="(max-width: 460px) 100vw, 450px"
-                          alt=""
-                        />
+                        <img src={{t.image_url}} alt="" />
                       </a>
                       <h3>
                         <a href={{this.topicHref t}} data-topic-id={{t.id}}>

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -16,4 +16,3 @@ en:
       always_link_to_first_post: Always link to the first post in the topic, even if it has been read before
       mobile_style: If <code>show_all_always</code> is checked, the topics will be shown via a horizontal scroll by default. You can change this behaviour on smaller screens, and choose to stack them on anything smaller than 600px.
       featured_content_position: Advanced theme development&colon; this changes the plugin outlet for the component
-      featured_image_sizes: The resized image variants made available to the featured images, as <code>WIDTHxHEIGHT</code> values. The browser picks the smallest one that fits the slot at the current screen size and pixel density, which saves bandwidth and speeds up page load. Provide a few sizes covering standard and high-resolution screens. Discourse generates these in the background, so they may take a moment to appear the first time after changing this; until then the full-size image is used.

--- a/settings.yml
+++ b/settings.yml
@@ -70,7 +70,3 @@ featured_content_position:
     - above_main_container
     - below_discovery_categories
     - discovery_list_controls_above
-
-featured_image_sizes:
-  default: "300x300|600x600|900x900"
-  type: list


### PR DESCRIPTION
This is a follow-up to https://github.com/discourse/discourse-homepage-feature-component/pull/96, I didn't consider that adding the modifier would result in a job impacting *all* topics, which is overkill for this case. The feature isn't worth it. 